### PR TITLE
Use atom-package-deps to install atom-linter automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ export default class LinterJsonLint {
 
   static regex = '.+?line\\s(\\d+)'
 
+  static activate() {
+    require("atom-package-deps").install("linter-jsonlint");
+  }
+
   static provideLinter() {
     return {
       grammarScopes: ['source.json'],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">=1.0.0"
   },
   "dependencies": {
-    "atom-package-deps": "^2.0.1",
+    "atom-package-deps": "^2.0.2",
     "jsonlint": "~1.6.2"
   },
   "package-deps": [

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
     "atom": ">=1.0.0"
   },
   "dependencies": {
+    "atom-package-deps": "^2.0.1",
     "jsonlint": "~1.6.2"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
ref #18 