### PR TITLE
Remove atom-linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/AtomLinter/linter-jsonlint#readme",
   "dependencies": {
-    "atom-linter": "^5.0.0",
     "atom-package-deps": "^4.0.1",
     "jsonlint": "~1.6.2"
   },


### PR DESCRIPTION
This package doesn't currently use `atom-linter`, remove it from the list of dependencies.