### PR TITLE
Update the CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,21 @@
 ### Project specific config ###
 
 # Installed for linting the project
-language: node_js
+language: generic
 
 matrix:
   include:
     - os: linux
-      node_js: "6"
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      node_js: "6"
       env: ATOM_CHANNEL=beta
 
     - os: osx
-      node_js: "6"
       env: ATOM_CHANNEL=stable
-
-env:
-  global:
-    - APM_TEST_PACKAGES=""
-    - ATOM_LINT_WITH_BUNDLED_NODE="false"
 
 ### Generic setup follows ###
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
-# Needed to disable the auto-install step running `npm install`
-install: true
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,8 @@
 ### Project specific config ###
 environment:
-  APM_TEST_PACKAGES:
-  ATOM_LINT_WITH_BUNDLED_NODE: "false"
-
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
-
-install:
-  # Install Node.js to run any configured linters
-  - ps: Install-Product node 6
 
 ### Generic setup follows ###
 build_script:

--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,8 @@
 test:
   override:
-    - curl -Ls https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.sh | sh
+    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
 
 dependencies:
   override:
+    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
     - echo "Managed in the script"
-
-machine:
-  node:
-    version: 6
-  environment:
-    ATOM_LINT_WITH_BUNDLED_NODE: "false"
-    APM_TEST_PACKAGES: ""


### PR DESCRIPTION
* APM's bundled Node.js is new enough, installing Node.js v6 is no longer necessary
* Move CircleCI to the atom/ci script
* Use the bundled Node.js for linting again